### PR TITLE
[Fix:ISSUE415] correct paused youtube video overlay setting

### DIFF
--- a/src/interventions/youtube/prompt_before_watch/frontend.js
+++ b/src/interventions/youtube/prompt_before_watch/frontend.js
@@ -374,23 +374,6 @@ function main() {
     return // duplicate call to main
   }
   prev_location_href = window.location.href
-  // we need to clear interval parsers first
-  if (end_pauser != null) { 
-    clearInterval(end_pauser); 
-    end_pauser = null
-  }
-  if (video_pauser != null) { 
-    clearInterval(video_pauser);
-    video_pauser = null 
-  }
-  if (ads_pauser != null) { 
-    clearInterval(ads_pauser); 
-    ads_pauser = null
-  }
-  if (ads_end_pauser != null) {
-    clearInterval(ads_end_pauser); 
-    ads_end_pauser = null
-  }
   // TODO: remove const busy waiting. currently cannot find a stable way
   setTimeout(function(){ 
     // detect if there is an ads
@@ -427,6 +410,23 @@ function main() {
 
 //Link to Fix: http://stackoverflow.com/questions/18397962/chrome-extension-is-not-loading-on-browser-navigation-at-youtube
 function afterNavigate() {
+    // we need to clear interval parsers first
+    if (end_pauser != null) { 
+      clearInterval(end_pauser); 
+      end_pauser = null
+    }
+    if (video_pauser != null) { 
+      clearInterval(video_pauser);
+      video_pauser = null 
+    }
+    if (ads_pauser != null) { 
+      clearInterval(ads_pauser); 
+      ads_pauser = null
+    }
+    if (ads_end_pauser != null) {
+      clearInterval(ads_end_pauser); 
+      ads_end_pauser = null
+    }
   if ('/watch' === location.pathname) {
     //if (video_pauser) {
     //  clearInterval(video_pauser);


### PR DESCRIPTION
This is a fix for the issue 415 **part a).**
1. correct paused youtube video overlay setting
2. adding total time alarm after the ads videos

Test Done:
1. Testing no ads video
	a. Before play: video paused, alarm shows up
	b. Click Play: video played
	c. After play: video paused, alarm shows up
2. Multiple click on no ads video
	a. Side listed videos: click through, should be no problem
	b. Switch back and forth: should be no problem
3. Testing on ads video
	a. Before the actual video: no pause till the end of the ads
	b. Click Play: video played
	c. After play: video paused, alarm shows up
4. Switch videos between ads and no ads video
	a. overlay position should be correct
	b. pause should be correct